### PR TITLE
WIP: a few changes for RemoteGallery

### DIFF
--- a/src/net/cachapa/remotegallery/ImageSlider.java
+++ b/src/net/cachapa/remotegallery/ImageSlider.java
@@ -45,15 +45,19 @@ public class ImageSlider extends FragmentActivity implements OnPageChangeListene
 		
 		// Register a menu for the long press
 		registerForContextMenu(viewPager);
-	}
-	
-	@Override
-	protected void onResume() {
-		super.onResume();
+
+		// Register for notification of downloads for the lifetime of this
+		// activity
 		downloadNotifier = DownloadNotifier.getInstance();
-		downloadNotifier.setOnDownloadListener(this);
+		downloadNotifier.addDownloadListener(this);
 	}
-	
+
+	@Override
+	protected void onDestroy() {
+		downloadNotifier.removeDownloadListener(this);
+		super.onDestroy();
+	}
+
 	/*** OnPageChangeListener ***/
 	@Override
 	public void onPageScrollStateChanged(int arg0) {

--- a/src/net/cachapa/remotegallery/ImageSlider.java
+++ b/src/net/cachapa/remotegallery/ImageSlider.java
@@ -21,6 +21,7 @@ public class ImageSlider extends FragmentActivity implements OnPageChangeListene
 	private static final int PAGE_MARGIN = 20;
 	
 	private String[] imagePaths;
+	private String[] thumbnailPaths;	
 	private ViewPager viewPager;
 	private DownloadNotifier downloadNotifier;
 	private int currentPage = 0;
@@ -33,9 +34,10 @@ public class ImageSlider extends FragmentActivity implements OnPageChangeListene
 		Intent intent = getIntent();
 		int index = intent.getIntExtra("index", 0);
 		imagePaths = intent.getStringArrayExtra("paths");
+		thumbnailPaths =  intent.getStringArrayExtra("thumbPaths");
 		
 		ImageSliderAdapter sliderAdapter = new ImageSliderAdapter(getSupportFragmentManager());
-		sliderAdapter.setImagePaths(imagePaths);
+		sliderAdapter.setImagePaths(imagePaths, thumbnailPaths);
 		
 		viewPager = (ViewPager) findViewById(R.id.viewPager);
 		viewPager.setAdapter(sliderAdapter);

--- a/src/net/cachapa/remotegallery/RemoteBrowser.java
+++ b/src/net/cachapa/remotegallery/RemoteBrowser.java
@@ -306,9 +306,11 @@ public class RemoteBrowser extends ListActivity implements OnClickListener, OnGl
 		// Build a list of images
 		DirListAdapter dirListAdapter = getListAdapter();
 		ArrayList<String> entries = new ArrayList<String>();
+		ArrayList<String> thumbEntries = new ArrayList<String>();
 		for (DirEntry entry : dirListAdapter.getDirEntries()) {
 			if (!entry.isDirectory) {
 				entries.add(AppPreferences.getCacheDir(serverConf) + currentPath + "/" + entry.name);
+				thumbEntries.add(AppPreferences.getThumbnailDir(serverConf) + currentPath + "/" + entry.name);				
 			}
 			else {
 				position--;
@@ -317,9 +319,12 @@ public class RemoteBrowser extends ListActivity implements OnClickListener, OnGl
 		
 		Intent imageViewerIntent = new Intent(RemoteBrowser.this, net.cachapa.remotegallery.ImageSlider.class);
 		String[] entriesString = new String[entries.size()];
+		String[] thumbEntriesString = new String[entries.size()];
 		entriesString = entries.toArray(entriesString);
+		thumbEntriesString = thumbEntries.toArray(thumbEntriesString);
 		imageViewerIntent.putExtra("index", position);
 		imageViewerIntent.putExtra("paths", entriesString);
+		imageViewerIntent.putExtra("thumbPaths", thumbEntriesString);		
 		startActivity(imageViewerIntent);
 	}
 	

--- a/src/net/cachapa/remotegallery/RemoteBrowser.java
+++ b/src/net/cachapa/remotegallery/RemoteBrowser.java
@@ -356,7 +356,8 @@ public class RemoteBrowser extends ListActivity implements OnClickListener, OnGl
 		for (int i = 0; i < size; i++) {
 			entry = (DirEntry) getListAdapter().getItem((i + firstPosition) % size);
 			path = currentPath + "/" + entry.name;
-			if (!entry.isDirectory && !entry.isThumbDownloading && !isThumbCached(entry)) {
+			if (!entry.isDirectory && !entry.alreadyDownloadedThumbOnce && !entry.isThumbDownloading && 
+			    !isThumbCached(entry)) {
 				new ImageThumbDownloader(entry).execute(path);
 				return;
 			}
@@ -364,7 +365,8 @@ public class RemoteBrowser extends ListActivity implements OnClickListener, OnGl
 		for (int i = 0; i < size; i++) {
 			entry = (DirEntry) getListAdapter().getItem((i + firstPosition) % size);
 			path = currentPath + "/" + entry.name;
-			if (!entry.isDirectory && !entry.isDownloading && !isCached(entry)) {
+			if (!entry.isDirectory && !entry.alreadyDownloadedOnce && !entry.isDownloading &&
+				!isCached(entry)) {
 				new ImageDownloader(entry).execute(path);
 				return;
 			}
@@ -481,6 +483,7 @@ public class RemoteBrowser extends ListActivity implements OnClickListener, OnGl
 		@Override
 		protected void onPreExecute() {
 			entry.isDownloading = true;
+			entry.alreadyDownloadedOnce = true;
 		}
 		
 		@Override
@@ -504,6 +507,7 @@ public class RemoteBrowser extends ListActivity implements OnClickListener, OnGl
 		@Override
 		protected void onPreExecute() {
 			entry.isThumbDownloading = true;
+			entry.alreadyDownloadedThumbOnce = true;
 		}
 
 		@Override
@@ -517,6 +521,13 @@ public class RemoteBrowser extends ListActivity implements OnClickListener, OnGl
 			entry.isThumbDownloading = false;
 			downloadNotifier.notifyDownloadComplete();
 		}
+		
+		@Override
+		public void logError(Ssh ssh, String log) {
+			// Ignore no thumbnail errors
+			if (!log.toLowerCase().contains("image contains no thumbnail")) {
+				super.logError(ssh, log);
+			}
 	}
 
 	private class DirListAdapter extends BaseAdapter implements ListAdapter, Filterable {

--- a/src/net/cachapa/remotegallery/RemoteBrowser.java
+++ b/src/net/cachapa/remotegallery/RemoteBrowser.java
@@ -549,6 +549,7 @@ public class RemoteBrowser extends ListActivity implements OnClickListener, OnGl
 			if (!log.toLowerCase().contains("image contains no thumbnail")) {
 				super.logError(ssh, log);
 			}
+		}
 	}
 
 	private class DirListAdapter extends BaseAdapter implements ListAdapter, Filterable {

--- a/src/net/cachapa/remotegallery/ssh/SshThumbnailImageReader.java
+++ b/src/net/cachapa/remotegallery/ssh/SshThumbnailImageReader.java
@@ -10,7 +10,6 @@ import net.cachapa.remotegallery.util.AppPreferences;
 import net.cachapa.remotegallery.util.ServerConf;
 import net.cachapa.remotegallery.util.Util;
 import android.content.Context;
-import android.util.DisplayMetrics;
 
 public class SshThumbnailImageReader extends Ssh {
 	private String path;

--- a/src/net/cachapa/remotegallery/ssh/SshThumbnailImageReader.java
+++ b/src/net/cachapa/remotegallery/ssh/SshThumbnailImageReader.java
@@ -12,32 +12,23 @@ import net.cachapa.remotegallery.util.Util;
 import android.content.Context;
 import android.util.DisplayMetrics;
 
-public class SshImageReader extends Ssh {
+public class SshThumbnailImageReader extends Ssh {
 	private String path;
 
-	public SshImageReader(Context context, ServerConf serverConf) {
+	public SshThumbnailImageReader(Context context, ServerConf serverConf) {
 		super(context, serverConf);
 	}
 	
 	public void getImage(String path, LogCallback logCallback) {
 		this.path = path;
-		DisplayMetrics dm = context.getResources().getDisplayMetrics();
-		int size = Math.max(dm.widthPixels, dm.heightPixels);
-		
-		String remoteCommand = "convert" +
-			" '" + serverConf.remotePath + path + "'" +
-			" -resize " + size +
-			" -quality 90" +
-			" -auto-orient" +
-			" -";
-		
+		String remoteCommand = "jhead -st - '" + serverConf.remotePath + path + "'";
 		execute(remoteCommand, logCallback);
 	}
 	
 	@Override
 	public void getDataStream(InputStream inputStream) throws IOException {
 		String imagePath = AppPreferences.getCacheDir(serverConf) + path;
-		File outputFile = new File(imagePath + ".temp");
+		File outputFile = new File(imagePath + ".tn.temp");
 		// Create the directory
 		File parent = new File(outputFile.getParent());
 		parent.mkdirs();
@@ -52,24 +43,22 @@ public class SshImageReader extends Ssh {
 		output.close();
 		
 		if (outputFile.length() > 0) {
-			// Generate the thumbnail if we don't have one
+			// Generate the thumbnail
 			String thumbnailPath = AppPreferences.getThumbnailDir(serverConf) + path;
-			if (!Util.isCached(thumbnailPath)) {
-			    int size = (int) (48 * context.getResources().getDisplayMetrics().density);
-
-			    // Create the thumbnails directory, and the .nomedia file, if necessary
-			    if (new File(new File(thumbnailPath).getParent()).mkdirs()) {
-			        File noMediaFile = new File(AppPreferences.getThumbnailDir(serverConf) + "/.nomedia");
-			        if (!noMediaFile.exists()) {
-			            noMediaFile.createNewFile();
-			        }
-			    }
-
-			    Util.generateThumbnail(imagePath + ".temp", thumbnailPath, size);
+			int size = (int) (48 * context.getResources().getDisplayMetrics().density);
+			
+			// Create the thumbnails directory, and the .nomedia file, if necessary
+			if (new File(new File(thumbnailPath).getParent()).mkdirs()) {
+				File noMediaFile = new File(AppPreferences.getThumbnailDir(serverConf) + "/.nomedia");
+				if (!noMediaFile.exists()) {
+					noMediaFile.createNewFile();
+				}
 			}
-
-			// Remove the .temp from the image filename
-			outputFile.renameTo(new File(imagePath));
+			
+			Util.generateThumbnail(imagePath + ".tn.temp", thumbnailPath, size);
+			
+			// Delete temp file
+			outputFile.delete();
 		}
 	}
 }

--- a/src/net/cachapa/remotegallery/util/DirEntry.java
+++ b/src/net/cachapa/remotegallery/util/DirEntry.java
@@ -5,7 +5,9 @@ public class DirEntry {
 	public boolean isDirectory;
 	public boolean isDownloading = false;
 	public boolean isThumbDownloading = false;
-
+	public boolean alreadyDownloadedOnce = false;
+	public boolean alreadyDownloadedThumbOnce = false;
+	
 	public DirEntry(String name, boolean isDirectory) {
 		this.name = name;
 		this.isDirectory = isDirectory;

--- a/src/net/cachapa/remotegallery/util/DirEntry.java
+++ b/src/net/cachapa/remotegallery/util/DirEntry.java
@@ -4,6 +4,7 @@ public class DirEntry {
 	public String name;
 	public boolean isDirectory;
 	public boolean isDownloading = false;
+	public boolean isThumbDownloading = false;
 
 	public DirEntry(String name, boolean isDirectory) {
 		this.name = name;

--- a/src/net/cachapa/remotegallery/util/DownloadNotifier.java
+++ b/src/net/cachapa/remotegallery/util/DownloadNotifier.java
@@ -1,9 +1,12 @@
 package net.cachapa.remotegallery.util;
 
+import java.util.ArrayList;
+import java.util.List;
+
 public class DownloadNotifier {
 	private static DownloadNotifier instance;
-	private onDownloadListener listener;
-	
+	private List<onDownloadListener> listeners = new ArrayList<onDownloadListener>();
+
 	protected DownloadNotifier() {
 	}
 	
@@ -13,19 +16,23 @@ public class DownloadNotifier {
 		}
 		return instance;
 	}
-	
-	public void setOnDownloadListener(onDownloadListener listener) {
-		this.listener = listener;
-	}
-	
+
 	public void notifyDownloadComplete() {
-		if (listener != null) {
+		for (onDownloadListener listener : listeners) {
 			listener.onDownloadComplete();
 		}
 	}
 	
-	
 	public interface onDownloadListener {
 		public void onDownloadComplete();
+	}
+
+	public void addDownloadListener(onDownloadListener listener) {
+		if (!listeners.contains(listener))
+			listeners.add(listener);
+	}
+
+	public void removeDownloadListener(onDownloadListener listener) {
+		listeners.remove(listener);
 	}
 }

--- a/src/net/cachapa/remotegallery/util/ImageSliderAdapter.java
+++ b/src/net/cachapa/remotegallery/util/ImageSliderAdapter.java
@@ -18,6 +18,7 @@ import android.widget.ProgressBar;
 
 public class ImageSliderAdapter extends FragmentStatePagerAdapter {
 	private String[] imagePaths;
+	private String[] thumbnailPaths;
 	public static ArrayList<ImageFragment> pages;
 
 	public ImageSliderAdapter(FragmentManager fm) {
@@ -27,18 +28,19 @@ public class ImageSliderAdapter extends FragmentStatePagerAdapter {
 
 	@Override
 	public Fragment getItem(int position) {
-		return ImageFragment.newInstance(imagePaths[position]);
+		return ImageFragment.newInstance(imagePaths[position], thumbnailPaths[position]);
 	}
 
 	@Override
 	public int getCount() {
 		return imagePaths.length;
 	}
-	
-	public void setImagePaths(String[] imagePaths) {
+
+	public void setImagePaths(String[] imagePaths, String[] thumbnailPaths) {
 		this.imagePaths = imagePaths;
+		this.thumbnailPaths = thumbnailPaths;
 	}
-	
+
 	@Override
 	public void notifyDataSetChanged() {
 		int size = pages.size();
@@ -47,58 +49,70 @@ public class ImageSliderAdapter extends FragmentStatePagerAdapter {
 		}
 		super.notifyDataSetChanged();
 	}
-	
-	
+
 	public static class ImageFragment extends Fragment {
 		String imagePath;
+		String thumbnailPath;
 		ImageView imageView;
 		ProgressBar progressBar;
-		
-		static ImageFragment newInstance(String imagePath) {
+		boolean gotHq = false;
+
+		static ImageFragment newInstance(String imagePath, String thumbnailPath) {
 			ImageFragment fragment = new ImageFragment();
-			
+
 //			// Pass the image path as an argument
 			Bundle args = new Bundle();
 			args.putString("imagePath", imagePath);
+			args.putString("thumbnailPath", thumbnailPath);
 			fragment.setArguments(args);
-			
+
 			return fragment;
 		}
-		
+
 		@Override
 		public void onCreate(Bundle savedInstanceState) {
 			super.onCreate(savedInstanceState);
 			imagePath = getArguments().getString("imagePath");
+			thumbnailPath = getArguments().getString("thumbnailPath");
 		}
-		
+
 		@Override
 		public View onCreateView(LayoutInflater inflater, ViewGroup container, Bundle savedInstanceState) {
 			View page = inflater.inflate(R.layout.image_viewer, container, false);
-			
+
 			imageView = (ImageView) page.findViewById(R.id.imageView);
 			progressBar = (ProgressBar) page.findViewById(R.id.progressBar);
 			loadImage();
-			
+
 			pages.add(this);
-			
+
 			return page;
 		}
-		
+
 		public void loadImage() {
-			if (imageView.getDrawable() == null && Util.isCached(imagePath)) {
+			// If we already got the HQ version, do nothing.
+			if (gotHq)
+				return;
+
+			// Prefer the HQ image, fallback to the thumbnail
+			if (Util.isCached(imagePath)) {
 				imageView.setImageBitmap(BitmapFactory.decodeFile(imagePath));
 				progressBar.setVisibility(View.GONE);
+				gotHq = true;
+			} else if (imageView.getDrawable() == null && Util.isCached(thumbnailPath)) {
+				imageView.setImageBitmap(BitmapFactory.decodeFile(thumbnailPath));
 			}
 		}
-		
+
 		@Override
 		public void onDestroy() {
-			// This method is called automatically by the FragmentStatePageAdapter
-			// for any existing page 2 pages away from the current one.
-			// We use this opportunity and recycle the bitmap to avoid exceeding the VM budget
-			
+			// This method is called automatically by the
+			// FragmentStatePageAdapter for any existing page 2 pages away from the current one.
+			// We use this opportunity and recycle the bitmap to avoid exceeding
+			// the VM budget
+
 			pages.remove(this);
-			
+
 			BitmapDrawable drawable = (BitmapDrawable) imageView.getDrawable();
 			if (drawable != null) {
 				Bitmap image = drawable.getBitmap();


### PR DESCRIPTION
RemoteGallery is excellent - just what I was looking for!

I thought I'd have a go at hacking a bit on it, and I've a got a few changes which might be of interest (probably not quite ready to pull just yet, but almost there).

1) the main change uses 'jhead' on the server to extract the JPEG thumbnail from image files before fetching the 'full quality' version. I was finding that large directories would take a long time to populate the list (imagemagick was taking a long time to run). This change speeds up population of the list significantly for slow servers on fast network connections (at the expense of more fetches in total). Perhaps this should be an option, rather than always on? We fallback to the generated thumbnail if there is no embedded thumbnail.

2) a fix a bug where we never fetch images on the ImageSlider view if we didn't
start fetching them on the RemoteBrowser activity.

3) prevent infinite looping if a fetch fails.

Let me know if these changes are useful for you!
